### PR TITLE
feat: add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,18 @@ jobs:
         with:
           go-version: "1.24.x"
 
+      - uses: actions/create-github-app-token@v1
+        id: homebrew-token
+        with:
+          app-id: ${{ vars.HOMEBREW_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
+          owner: jimatomo
+          repositories: homebrew-tap
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,3 +36,17 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+brews:
+  - name: coragent
+    repository:
+      owner: jimatomo
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/jimatomo/cortex-agent-cli"
+    description: "CLI tool for managing Snowflake Cortex Agent deployments"
+    install: |
+      bin.install "coragent"
+    test: |
+      system "#{bin}/coragent", "--help"
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ CLI tool for managing Snowflake Cortex Agent deployments via the REST API.
 
 ## Install
 
+### Homebrew
+
+```bash
+brew install jimatomo/tap/coragent
+```
+
 ### Quick Install (Recommended)
 
 ```bash


### PR DESCRIPTION
## Summary

- `.goreleaser.yaml` に `brews` セクションを追加し、リリース時に `jimatomo/homebrew-tap/Formula/coragent.rb` を自動生成
- `.github/workflows/release.yml` に `actions/create-github-app-token@v1` ステップを追加し、GitHub App 経由でタップリポジトリへの書き込みトークンを生成
- `README.md` の `## Install` セクション先頭に `### Homebrew` を追加

Closes #10

## 前提条件（マージ前にユーザーが手動で実施）

- [x] `jimatomo/homebrew-tap` リポジトリを作成
- [x] GitHub App (`cortex-agent-cli-releaser`) を作成し、`homebrew-tap` にインストール
- [x] `cortex-agent-cli` リポジトリに Variable `HOMEBREW_APP_ID` と Secret `HOMEBREW_APP_PRIVATE_KEY` を登録

## Test plan

- [x] `v*` タグをプッシュしてリリースワークフローを実行
- [x] `jimatomo/homebrew-tap/Formula/coragent.rb` が生成されることを確認
- [x] `brew tap jimatomo/tap && brew install coragent && coragent --help` で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)