### PR TITLE
Add query tag propagation and fix run thread ID parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ Settings are resolved in the following order (highest priority first):
 3. Environment variables: `SNOWFLAKE_DATABASE`, `SNOWFLAKE_SCHEMA`, etc.
 4. Snowflake CLI config.toml (`~/.snowflake/config.toml`)
 
+### `.coragent.toml`
+
+Project and user settings can also be defined in `.coragent.toml` (current directory) or `~/.coragent/config.toml`.
+
+```toml
+[query_tag]
+base = "coragent"
+```
+
+`query_tag.base` sets the base value used for supported Snowflake query tagging. When unset, `coragent` is used. The CLI appends the current command name for supported SQL-backed requests, for example `coragent:plan`, `coragent:run` (agent selection lookup), or `coragent:feedback`.
+
 ### Snowflake CLI config.toml
 
 The CLI reads `~/.snowflake/config.toml` — the same file used by Snowflake CLI (`snow`) and the Python connector. The file is searched in the following order:

--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -88,9 +88,42 @@ func (c *Client) DescribeAgent(ctx context.Context, db, schema, name string) (De
 
 // ListAgents returns a summary list of agents in the given database and schema.
 func (c *Client) ListAgents(ctx context.Context, db, schema string) ([]AgentListItem, error) {
-	var out []AgentListItem
-	if err := c.doJSON(ctx, http.MethodGet, c.agentsURL(db, schema), nil, &out); err != nil {
+	stmt := fmt.Sprintf(
+		"SHOW AGENTS IN SCHEMA %s.%s",
+		identifierSegment(db),
+		identifierSegment(schema),
+	)
+	resp, err := c.executeStatement(ctx, db, schema, stmt)
+	if err != nil {
 		return nil, err
+	}
+
+	colIndex := make(map[string]int)
+	for i, col := range resp.ResultSetMetaData.RowType {
+		colIndex[strings.ToLower(col.Name)] = i
+	}
+	nameIdx, hasName := colIndex["name"]
+	commentIdx, hasComment := colIndex["comment"]
+	if !hasName {
+		return nil, fmt.Errorf("show agents: missing name column")
+	}
+
+	out := make([]AgentListItem, 0, len(resp.Data))
+	for _, row := range resp.Data {
+		if nameIdx >= len(row) {
+			continue
+		}
+		name, ok := row[nameIdx].(string)
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		item := AgentListItem{Name: name}
+		if hasComment && commentIdx < len(row) {
+			if comment, ok := row[commentIdx].(string); ok {
+				item.Comment = comment
+			}
+		}
+		out = append(out, item)
 	}
 	return out, nil
 }

--- a/internal/api/agent_test.go
+++ b/internal/api/agent_test.go
@@ -247,6 +247,63 @@ func TestDescribeAgentFull_ToolResources(t *testing.T) {
 	}
 }
 
+func TestListAgents_ShowAgents(t *testing.T) {
+	cols := []string{"name", "comment"}
+	row1 := []any{"agent_one", "first"}
+	row2 := []any{"agent_two", ""}
+
+	var gotStatement string
+	var gotQueryTag string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req sqlStatementRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotStatement = req.Statement
+		if req.Parameters != nil {
+			gotQueryTag = req.Parameters["query_tag"]
+		}
+
+		resp := sqlStatementResponse{
+			Data: [][]any{row1, row2},
+			ResultSetMetaData: struct {
+				RowType []sqlRowType `json:"rowType"`
+			}{
+				RowType: []sqlRowType{{Name: cols[0]}, {Name: cols[1]}},
+			},
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	c := newDescribeTestClient(t, srv)
+	listed, err := c.ListAgents(WithQueryTagCommand(context.Background(), "run"), "MY_DB", "PUBLIC")
+	if err != nil {
+		t.Fatalf("ListAgents() error = %v", err)
+	}
+	if gotStatement != "SHOW AGENTS IN SCHEMA MY_DB.PUBLIC" {
+		t.Fatalf("statement = %q, want %q", gotStatement, "SHOW AGENTS IN SCHEMA MY_DB.PUBLIC")
+	}
+	if gotQueryTag != "coragent:run" {
+		t.Fatalf("query_tag = %q, want %q", gotQueryTag, "coragent:run")
+	}
+	if len(listed) != 2 {
+		t.Fatalf("len(listed) = %d, want 2", len(listed))
+	}
+	if listed[0].Name != "agent_one" || listed[0].Comment != "first" {
+		t.Fatalf("listed[0] = %+v", listed[0])
+	}
+	if listed[1].Name != "agent_two" {
+		t.Fatalf("listed[1] = %+v", listed[1])
+	}
+}
+
 // TestDescribeAgentFull_AllKnownColumns verifies that all known SQL columns
 // are handled without appearing in UnmappedColumns.
 func TestDescribeAgentFull_AllKnownColumns(t *testing.T) {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -15,12 +15,13 @@ import (
 
 // Client is the Snowflake Cortex Agent API client.
 type Client struct {
-	baseURL   *url.URL
-	role      string
-	userAgent string
-	http      *http.Client
-	authCfg   auth.Config
-	log       *slog.Logger
+	baseURL      *url.URL
+	role         string
+	userAgent    string
+	http         *http.Client
+	authCfg      auth.Config
+	queryTagBase string
+	log          *slog.Logger
 }
 
 // APIError represents a non-2xx HTTP response from the Snowflake API.
@@ -79,11 +80,12 @@ func NewClient(cfg auth.Config) (*Client, error) {
 // Intended for use in tests against mock HTTP servers — no real Snowflake credentials required.
 func NewClientForTest(base *url.URL, cfg auth.Config) *Client {
 	return &Client{
-		baseURL:   base,
-		userAgent: "test",
-		http:      &http.Client{Timeout: 30 * time.Second},
-		authCfg:   cfg,
-		log:       discardLogger(),
+		baseURL:      base,
+		userAgent:    "test",
+		http:         &http.Client{Timeout: 30 * time.Second},
+		authCfg:      cfg,
+		queryTagBase: "coragent",
+		log:          discardLogger(),
 	}
 }
 
@@ -112,13 +114,19 @@ func NewClientWithDebug(cfg auth.Config, debug bool) (*Client, error) {
 	}
 
 	client := &Client{
-		baseURL:   base,
-		role:      strings.ToUpper(strings.TrimSpace(cfg.Role)),
-		userAgent: "coragent",
-		http:      &http.Client{Timeout: 60 * time.Second},
-		authCfg:   cfg,
-		log:       log,
+		baseURL:      base,
+		role:         strings.ToUpper(strings.TrimSpace(cfg.Role)),
+		userAgent:    "coragent",
+		http:         &http.Client{Timeout: 60 * time.Second},
+		authCfg:      cfg,
+		queryTagBase: "coragent",
+		log:          log,
 	}
 
 	return client, nil
+}
+
+// SetQueryTagBase overrides the default base tag used for supported Snowflake requests.
+func (c *Client) SetQueryTagBase(base string) {
+	c.queryTagBase = strings.TrimSpace(base)
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"sort"
 	"strings"
 	"testing"
@@ -34,6 +38,48 @@ func TestIsNotFoundError(t *testing.T) {
 				t.Errorf("isNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveQueryTag(t *testing.T) {
+	c := &Client{queryTagBase: "team-cli"}
+
+	if got := c.resolveQueryTag(context.Background()); got != "team-cli" {
+		t.Fatalf("resolveQueryTag() = %q, want %q", got, "team-cli")
+	}
+
+	ctx := WithQueryTagCommand(context.Background(), "apply")
+	if got := c.resolveQueryTag(ctx); got != "team-cli:apply" {
+		t.Fatalf("resolveQueryTag(with command) = %q, want %q", got, "team-cli:apply")
+	}
+}
+
+func TestDoJSON_SQLAddsQueryTag(t *testing.T) {
+	var gotPayload sqlStatementRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	client := newDescribeTestClient(t, srv)
+	client.baseURL = base
+	client.SetQueryTagBase("team-cli")
+
+	payload := sqlStatementRequest{Statement: "SELECT 1"}
+	if err := client.doJSON(WithQueryTagCommand(context.Background(), "feedback"), http.MethodPost, client.sqlURL(), payload, nil); err != nil {
+		t.Fatalf("doJSON() error = %v", err)
+	}
+
+	if gotPayload.Parameters["query_tag"] != "team-cli:feedback" {
+		t.Fatalf("parameters.query_tag = %q, want %q", gotPayload.Parameters["query_tag"], "team-cli:feedback")
 	}
 }
 
@@ -412,8 +458,8 @@ func TestMergeAgentSpecs(t *testing.T) {
 			},
 		},
 		{
-			name: "tools overwritten",
-			base: agent.AgentSpec{Tools: []agent.Tool{{ToolSpec: map[string]any{"name": "old"}}}},
+			name:  "tools overwritten",
+			base:  agent.AgentSpec{Tools: []agent.Tool{{ToolSpec: map[string]any{"name": "old"}}}},
 			extra: agent.AgentSpec{Tools: []agent.Tool{{ToolSpec: map[string]any{"name": "new"}}}},
 			check: func(s agent.AgentSpec) error {
 				if len(s.Tools) != 1 || s.Tools[0].ToolSpec["name"] != "new" {

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -14,6 +14,12 @@ import (
 )
 
 func (c *Client) doJSON(ctx context.Context, method, urlStr string, payload any, out any) error {
+	if method == http.MethodPost {
+		if sqlPayload, ok := payload.(sqlStatementRequest); ok {
+			payload = c.sqlRequestWithQueryTag(ctx, sqlPayload)
+		}
+	}
+
 	var body io.Reader
 	var reqBody []byte
 	if payload != nil {

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -15,11 +15,12 @@ import (
 
 // sqlStatementRequest is the request body for the Snowflake SQL Statement API.
 type sqlStatementRequest struct {
-	Statement string `json:"statement"`
-	Database  string `json:"database,omitempty"`
-	Schema    string `json:"schema,omitempty"`
-	Warehouse string `json:"warehouse,omitempty"`
-	Role      string `json:"role,omitempty"`
+	Statement  string            `json:"statement"`
+	Database   string            `json:"database,omitempty"`
+	Schema     string            `json:"schema,omitempty"`
+	Warehouse  string            `json:"warehouse,omitempty"`
+	Role       string            `json:"role,omitempty"`
+	Parameters map[string]string `json:"parameters,omitempty"`
 }
 
 type sqlRowType struct {

--- a/internal/api/query_tag.go
+++ b/internal/api/query_tag.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"strings"
+)
+
+type queryTagContextKey struct{}
+
+// WithQueryTagCommand attaches the originating CLI command to the request context.
+func WithQueryTagCommand(ctx context.Context, command string) context.Context {
+	return context.WithValue(ctx, queryTagContextKey{}, strings.TrimSpace(command))
+}
+
+func (c *Client) resolveQueryTag(ctx context.Context) string {
+	base := strings.TrimSpace(c.queryTagBase)
+	if base == "" {
+		base = "coragent"
+	}
+	command, _ := ctx.Value(queryTagContextKey{}).(string)
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return base
+	}
+	return base + ":" + command
+}
+
+func (c *Client) sqlRequestWithQueryTag(ctx context.Context, payload sqlStatementRequest) sqlStatementRequest {
+	tag := c.resolveQueryTag(ctx)
+	if tag == "" {
+		return payload
+	}
+	if payload.Parameters == nil {
+		payload.Parameters = map[string]string{}
+	}
+	payload.Parameters["query_tag"] = tag
+	return payload
+}

--- a/internal/api/run.go
+++ b/internal/api/run.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -91,6 +92,39 @@ type ResponseMetadata struct {
 	MessageID int64  `json:"message_id,omitempty"`
 }
 
+// UnmarshalJSON handles thread_id as either a string or integer.
+func (m *ResponseMetadata) UnmarshalJSON(data []byte) error {
+	type Alias ResponseMetadata
+	aux := &struct {
+		ThreadID json.RawMessage `json:"thread_id"`
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if aux.ThreadID == nil {
+		return nil
+	}
+
+	var strID string
+	if err := json.Unmarshal(aux.ThreadID, &strID); err == nil {
+		m.ThreadID = strID
+		return nil
+	}
+
+	var intID int64
+	if err := json.Unmarshal(aux.ThreadID, &intID); err == nil {
+		m.ThreadID = strconv.FormatInt(intID, 10)
+		return nil
+	}
+
+	return fmt.Errorf("thread_id must be string or integer")
+}
+
 // ResponseContentBlock represents a content block in the final response.
 type ResponseContentBlock struct {
 	Type       string          `json:"type"` // "text", "thinking", "tool_use", "tool_result"
@@ -121,6 +155,43 @@ type MetadataEvent struct {
 		ThreadID  string `json:"thread_id"`
 		Role      string `json:"role"`
 	} `json:"metadata"`
+}
+
+// UnmarshalJSON handles metadata.thread_id as either a string or integer.
+func (m *MetadataEvent) UnmarshalJSON(data []byte) error {
+	type metadataAlias struct {
+		MessageID int64           `json:"message_id"`
+		ThreadID  json.RawMessage `json:"thread_id"`
+		Role      string          `json:"role"`
+	}
+	aux := struct {
+		Metadata metadataAlias `json:"metadata"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	m.Metadata.MessageID = aux.Metadata.MessageID
+	m.Metadata.Role = aux.Metadata.Role
+
+	if aux.Metadata.ThreadID == nil {
+		return nil
+	}
+
+	var strID string
+	if err := json.Unmarshal(aux.Metadata.ThreadID, &strID); err == nil {
+		m.Metadata.ThreadID = strID
+		return nil
+	}
+
+	var intID int64
+	if err := json.Unmarshal(aux.Metadata.ThreadID, &intID); err == nil {
+		m.Metadata.ThreadID = strconv.FormatInt(intID, 10)
+		return nil
+	}
+
+	return fmt.Errorf("metadata.thread_id must be string or integer")
 }
 
 // RunAgentOptions configures callbacks for streaming events.

--- a/internal/api/run_test.go
+++ b/internal/api/run_test.go
@@ -149,6 +149,34 @@ func TestParseSSEStream_Response(t *testing.T) {
 	}
 }
 
+func TestParseSSEStream_ResponseIntegerThreadID(t *testing.T) {
+	body := "event: response\ndata: {\"content\":[{\"type\":\"text\",\"text\":\"answer\"}],\"metadata\":{\"thread_id\":123,\"message_id\":99}}\n\n"
+	var metaTID string
+	var metaMID int64
+	opts := RunAgentOptions{
+		OnMetadata: func(threadID string, messageID int64) {
+			metaTID = threadID
+			metaMID = messageID
+		},
+	}
+	resp, err := parseSSEStream(strings.NewReader(body), opts, noopLog)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.Metadata == nil {
+		t.Fatal("expected response metadata")
+	}
+	if resp.Metadata.ThreadID != "123" {
+		t.Errorf("response metadata threadID = %q, want %q", resp.Metadata.ThreadID, "123")
+	}
+	if metaTID != "123" {
+		t.Errorf("callback metadata threadID = %q, want %q", metaTID, "123")
+	}
+	if metaMID != 99 {
+		t.Errorf("callback metadata messageID = %d, want %d", metaMID, 99)
+	}
+}
+
 func TestParseSSEStream_Status(t *testing.T) {
 	body := "event: response.status\ndata: {\"status\":\"running\",\"message\":\"Processing query\",\"sequence_number\":1}\n\n"
 	var gotStatus, gotMessage string
@@ -227,6 +255,28 @@ func TestParseSSEStream_EmptyBody(t *testing.T) {
 	}
 	if resp != nil {
 		t.Errorf("expected nil response for empty body, got %+v", resp)
+	}
+}
+
+func TestParseSSEStream_MetadataIntegerThreadID(t *testing.T) {
+	body := "event: metadata\ndata: {\"metadata\":{\"thread_id\":456,\"message_id\":789,\"role\":\"assistant\"}}\n\n"
+	var tid string
+	var mid int64
+	opts := RunAgentOptions{
+		OnMetadata: func(threadID string, messageID int64) {
+			tid = threadID
+			mid = messageID
+		},
+	}
+	_, err := parseSSEStream(strings.NewReader(body), opts, noopLog)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tid != "456" {
+		t.Errorf("threadID = %q, want %q", tid, "456")
+	}
+	if mid != 789 {
+		t.Errorf("messageID = %d, want %d", mid, 789)
 	}
 }
 

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -57,7 +56,7 @@ func newApplyCmd(opts *RootOptions) *cobra.Command {
 				return err
 			}
 
-			planItems, err := buildPlanItems(context.Background(), specs, opts, cfg, client, client)
+			planItems, err := buildPlanItems(commandContext("apply"), specs, opts, cfg, client, client)
 			if err != nil {
 				return err
 			}
@@ -87,7 +86,7 @@ func newApplyCmd(opts *RootOptions) *cobra.Command {
 				}
 			}
 
-			appliedItems, err := executeApply(context.Background(), planItems, client, client)
+			appliedItems, err := executeApply(commandContext("apply"), planItems, client, client)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"coragent/internal/api"
 	"coragent/internal/auth"
+	"coragent/internal/config"
 	"coragent/internal/grant"
 )
 
@@ -21,6 +23,7 @@ func buildClient(opts *RootOptions) (*api.Client, error) {
 	if err != nil {
 		return nil, UserErr(err)
 	}
+	client.SetQueryTagBase(strings.TrimSpace(config.LoadCoragentConfig().QueryTag.Base))
 	return client, nil
 }
 
@@ -33,7 +36,12 @@ func buildClientAndCfg(opts *RootOptions) (*api.Client, auth.Config, error) {
 	if err != nil {
 		return nil, auth.Config{}, UserErr(err)
 	}
+	client.SetQueryTagBase(strings.TrimSpace(config.LoadCoragentConfig().QueryTag.Base))
 	return client, cfg, nil
+}
+
+func commandContext(command string) context.Context {
+	return api.WithQueryTagCommand(context.Background(), command)
 }
 
 // confirm prints a [y/N] prompt to stdout and reads one line from r.

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -58,7 +57,7 @@ func newDeleteCmd(opts *RootOptions) *cobra.Command {
 					return fmt.Errorf("%s: %w", item.Path, err)
 				}
 
-				_, exists, err := client.GetAgent(context.Background(), target.Database, target.Schema, item.Spec.Name)
+				_, exists, err := client.GetAgent(commandContext("delete"), target.Database, target.Schema, item.Spec.Name)
 				if err != nil {
 					return fmt.Errorf("snowflake API error: %w", err)
 				}
@@ -114,7 +113,7 @@ func newDeleteCmd(opts *RootOptions) *cobra.Command {
 				}
 
 				fmt.Fprintf(os.Stdout, "Deleting %s... ", item.Parsed.Spec.Name)
-				if err := client.DeleteAgent(context.Background(), item.Target.Database, item.Target.Schema, item.Parsed.Spec.Name); err != nil {
+				if err := client.DeleteAgent(commandContext("delete"), item.Target.Database, item.Target.Schema, item.Parsed.Spec.Name); err != nil {
 					fmt.Fprintln(os.Stdout, "failed")
 					return fmt.Errorf("snowflake API error: %w", err)
 				}
@@ -128,4 +127,3 @@ func newDeleteCmd(opts *RootOptions) *cobra.Command {
 	cmd.Flags().BoolVarP(&recursive, "recursive", "R", false, "Recursively load agents from subdirectories")
 	return cmd
 }
-

--- a/internal/cli/eval.go
+++ b/internal/cli/eval.go
@@ -225,7 +225,7 @@ func runEvalTest(client *api.Client, target Target, agentName string, tc agent.E
 		ExpectedResponse: tc.ExpectedResponse,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(commandContext("eval"), 15*time.Minute)
 	defer cancel()
 
 	// Run agent only when question is specified

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -36,7 +35,7 @@ func newExportCmd(opts *RootOptions) *cobra.Command {
 				return err
 			}
 
-			result, err := client.DescribeAgent(context.Background(), target.Database, target.Schema, name)
+			result, err := client.DescribeAgent(commandContext("export"), target.Database, target.Schema, name)
 			if err != nil {
 				return err
 			}
@@ -194,4 +193,3 @@ func reorderMappingKeys(node *yaml.Node, priority []string) {
 	}
 	node.Content = result
 }
-

--- a/internal/cli/feedback.go
+++ b/internal/cli/feedback.go
@@ -140,7 +140,7 @@ By default, only negative feedback is shown. Use --all to show all feedback.`,
 					if err != nil {
 						return err
 					}
-					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					ctx, cancel := context.WithTimeout(commandContext("feedback"), 30*time.Second)
 					defer cancel()
 					exists, err := client.FeedbackTableExists(ctx, remoteDb, remoteSchema, remoteTable)
 					if err != nil {
@@ -177,7 +177,7 @@ By default, only negative feedback is shown. Use --all to show all feedback.`,
 				return nil
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(commandContext("feedback"), 60*time.Second)
 			defer cancel()
 
 			var remoteClient feedbackClient
@@ -422,7 +422,7 @@ func runFeedbackInit(cmd *cobra.Command, opts *RootOptions, appCfg config.Corage
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(commandContext("feedback"), 30*time.Second)
 	defer cancel()
 	exists, err := client.FeedbackTableExists(ctx, db, schema, table)
 	if err != nil {

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -44,7 +43,7 @@ func newPlanCmd(opts *RootOptions) *cobra.Command {
 				return err
 			}
 
-			planItems, err := buildPlanItems(context.Background(), specs, opts, cfg, client, client)
+			planItems, err := buildPlanItems(commandContext("plan"), specs, opts, cfg, client, client)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -77,7 +77,7 @@ to continue a specific thread, or --without-thread for single-turn mode.`,
 				return err
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+			ctx, cancel := context.WithTimeout(commandContext("run"), 15*time.Minute)
 			defer cancel()
 
 			// Determine agent name
@@ -110,7 +110,7 @@ to continue a specific thread, or --without-thread for single-turn mode.`,
 				}
 			}
 
-			ctx, cancel = context.WithTimeout(context.Background(), 15*time.Minute)
+			ctx, cancel = context.WithTimeout(commandContext("run"), 15*time.Minute)
 			defer cancel()
 
 			// Determine thread settings
@@ -280,4 +280,3 @@ to continue a specific thread, or --without-thread for single-turn mode.`,
 
 	return cmd
 }
-

--- a/internal/cli/threads.go
+++ b/internal/cli/threads.go
@@ -193,7 +193,7 @@ func handleDeleteMode(reader *bufio.Reader, client *api.Client, state *thread.St
 	}
 
 	// Delete threads
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(commandContext("threads"), 30*time.Second)
 	defer cancel()
 
 	for _, t := range toDelete {
@@ -241,7 +241,7 @@ func deleteThreadByID(client *api.Client, state *thread.StateStore, threadID str
 	}
 
 	// Delete from API
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(commandContext("threads"), 30*time.Second)
 	defer cancel()
 
 	if err := client.DeleteThread(ctx, threadID); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 type CoragentConfig struct {
 	Eval     EvalSettings     `toml:"eval"`
 	Feedback FeedbackSettings `toml:"feedback"`
+	QueryTag QueryTagSettings `toml:"query_tag"`
 }
 
 // FeedbackSettings holds feedback-related configuration.
@@ -36,6 +37,11 @@ type EvalSettings struct {
 	JudgeModel             string   `toml:"judge_model"`
 	ResponseScoreThreshold int      `toml:"response_score_threshold"`
 	IgnoreTools            []string `toml:"ignore_tools"`
+}
+
+// QueryTagSettings configures the base query tag value used for Snowflake requests.
+type QueryTagSettings struct {
+	Base string `toml:"base"`
 }
 
 // LoadCoragentConfig loads configuration from .coragent.toml.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -200,3 +200,53 @@ output_dir = "./out"
 			cfg.Feedback.Remote.Database, cfg.Feedback.Remote.Schema, cfg.Feedback.Remote.Table)
 	}
 }
+
+func TestLoadCoragentConfig_QueryTagBase(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origDir) })
+	os.Chdir(dir)
+
+	content := `[query_tag]
+base = "team-cli"
+`
+	if err := os.WriteFile(filepath.Join(dir, ".coragent.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := LoadCoragentConfig()
+	if cfg.QueryTag.Base != "team-cli" {
+		t.Errorf("expected query tag base team-cli, got %q", cfg.QueryTag.Base)
+	}
+}
+
+func TestLoadCoragentConfig_QueryTagBaseGlobalFallback(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	workDir := filepath.Join(dir, "work")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir work: %v", err)
+	}
+	os.Chdir(workDir)
+
+	fakeHome := filepath.Join(dir, "home")
+	coragentDir := filepath.Join(fakeHome, ".coragent")
+	if err := os.MkdirAll(coragentDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	content := `[query_tag]
+base = "global-base"
+`
+	if err := os.WriteFile(filepath.Join(coragentDir, "config.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	t.Setenv("HOME", fakeHome)
+
+	cfg := LoadCoragentConfig()
+	if cfg.QueryTag.Base != "global-base" {
+		t.Errorf("expected global query tag base, got %q", cfg.QueryTag.Base)
+	}
+}

--- a/internal/regression/mock.go
+++ b/internal/regression/mock.go
@@ -160,6 +160,8 @@ func (ms *MockServer) handleSQL(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(upper, "DESCRIBE AGENT "):
 		ms.handleDescribeAgent(w, stmt)
+	case strings.HasPrefix(upper, "SHOW AGENTS IN SCHEMA "):
+		ms.handleShowAgents(w)
 	case strings.HasPrefix(upper, "SHOW GRANTS ON AGENT "):
 		ms.handleShowGrants(w, stmt)
 	case strings.HasPrefix(upper, "GRANT "):
@@ -201,6 +203,24 @@ func (ms *MockServer) handleDescribeAgent(w http.ResponseWriter, stmt string) {
 	}
 	resp.Data = [][]any{
 		{string(specJSON), name, "", nil},
+	}
+	writeJSON(w, resp)
+}
+
+func (ms *MockServer) handleShowAgents(w http.ResponseWriter) {
+	list := ms.store.list()
+	var resp sqlStatementResponse
+	resp.ResultSetMetaData.RowType = []struct {
+		Name string `json:"name"`
+	}{
+		{Name: "name"},
+		{Name: "comment"},
+	}
+	resp.Data = make([][]any, 0, len(list))
+	for _, payload := range list {
+		name, _ := payload["name"].(string)
+		comment, _ := payload["comment"].(string)
+		resp.Data = append(resp.Data, []any{name, comment})
 	}
 	writeJSON(w, resp)
 }

--- a/reference/docs/commands/command-reference.md
+++ b/reference/docs/commands/command-reference.md
@@ -8,14 +8,14 @@ Canonical inventory of all coragent commands and subcommands, with implementatio
 - **Use:** `plan [path]`
 - **Entry:** `newPlanCmd` → RunE closure
 - **Dependencies:** `agent.LoadAgents`, `buildClientAndCfg`, `buildPlanItems`, `diff.DiffForCreate`, `diff.HasChanges`, `grant.GrantDiff`
-- **Side effects:** API read (GetAgent, ShowGrants); stdout only
+- **Side effects:** API read (GetAgent, ShowGrants); stdout only; SQL query tag defaults to `coragent:plan`
 - **Flags:** `-R`/`--recursive`
 
 ### apply [path]
 - **Use:** `apply [path]`
 - **Entry:** `newApplyCmd` → RunE closure
 - **Dependencies:** `agent.LoadAgents`, `buildClientAndCfg`, `buildPlanItems`, `executeApply`, `diff`, `grant`, `config.LoadCoragentConfig`
-- **Side effects:** API write (CreateAgent, UpdateAgent, ExecuteGrant, ExecuteRevoke); optional eval run; confirmation prompt
+- **Side effects:** API write (CreateAgent, UpdateAgent, ExecuteGrant, ExecuteRevoke); optional eval run; confirmation prompt; SQL query tag defaults to `coragent:apply`
 - **Flags:** `-y`/`--yes`, `-R`/`--recursive`, `--eval`
 
 ### delete [path]
@@ -36,7 +36,7 @@ Canonical inventory of all coragent commands and subcommands, with implementatio
 - **Use:** `export <agent-name>`
 - **Entry:** `newExportCmd` → RunE closure
 - **Dependencies:** `buildClientAndCfg`, `ResolveTargetForExport`, `client.DescribeAgent`
-- **Side effects:** API read; stdout or file write (`-o`)
+- **Side effects:** API read; stdout or file write (`-o`); SQL query tag defaults to `coragent:export`
 - **Flags:** `-o`/`--out`
 
 ### new
@@ -50,7 +50,7 @@ Canonical inventory of all coragent commands and subcommands, with implementatio
 - **Use:** `run [agent-name]`
 - **Entry:** `newRunCmd` → RunE closure
 - **Dependencies:** `buildClientAndCfg`, `ResolveTargetForExport`, `api.RunAgent`, `thread.LoadState`, `thread.Save`
-- **Side effects:** API (RunAgent, CreateThread); thread state read/write; streaming stdout/stderr
+- **Side effects:** API (RunAgent, CreateThread); thread state read/write; streaming stdout/stderr. When agent-name is omitted, the pre-run agent lookup uses the `run` SQL query tag context.
 - **Flags:** `-m`/`--message`, `--show-thinking`, `--new`, `--thread`, `--without-thread`
 
 ### threads
@@ -72,6 +72,7 @@ Canonical inventory of all coragent commands and subcommands, with implementatio
 - **Entry:** `newFeedbackCmd` → RunE closure
 - **Dependencies:** `config.LoadCoragentConfig`, `buildClientAndCfg`, `api.GetFeedback`, `api.FeedbackTableExists`, `api.SyncFeedbackFromEventsToTable`, `api.GetFeedbackFromTable`, `feedbackcache`
 - **Side effects:** API read/write (feedback fetch, remote table sync/update/clear); feedback cache read/write in local mode; optional remote table init. With `--no-refresh`, skip API fetch in local mode and skip remote table sync in remote mode, reading only saved state before any optional checked updates. With `--infer-negative`, request-only interactions are selected from observability with a separate SQL query and individually scored via `SELECT SNOWFLAKE.CORTEX.AI_COMPLETE(...) AS response` using a single-string prompt plus structured output; the model can be overridden with `feedback.judge_model`, and both negative and positive inferred classifications are persisted so previously judged rows are not rescored on later runs. Remote mode requires a table initialized via `feedback --init`, then uses transient stage-table `INSERT` and final `MERGE` statements. When `feedback --init` finds an existing remote table, it can rename that table to a timestamped backup before recreating the configured table.
+- **Side effects:** API read/write (feedback fetch, remote table sync/update/clear); feedback cache read/write in local mode; optional remote table init. With `--no-refresh`, skip API fetch in local mode and skip remote table sync in remote mode, reading only saved state before any optional checked updates. With `--infer-negative`, request-only interactions are selected from observability with a separate SQL query and individually scored via `SELECT SNOWFLAKE.CORTEX.AI_COMPLETE(...) AS response` using a single-string prompt plus structured output; the model can be overridden with `feedback.judge_model`, and both negative and positive inferred classifications are persisted so previously judged rows are not rescored on later runs. Remote mode requires a table initialized via `feedback --init`, then uses transient stage-table `INSERT` and final `MERGE` statements. When `feedback --init` finds an existing remote table, it can rename that table to a timestamped backup before recreating the configured table. SQL query tag defaults to `coragent:feedback`.
 - **Flags:** `--all`, `--limit`, `--json` (returns `[]` when no records), `-y`/`--yes`, `--include-checked`, `--no-tools`, `--no-refresh`, `--infer-negative`, `--clear`, `--init`
 
 ### login

--- a/reference/docs/components/api.md
+++ b/reference/docs/components/api.md
@@ -40,6 +40,17 @@ The API package provides the Snowflake Cortex Agent REST client and service inte
 
 Each request adds `Authorization: Bearer <token>` via `auth.AuthHeader(ctx, cfg)`. The client holds `auth.Config` and obtains tokens on demand (JWT or OAuth refresh).
 
+## Query Tagging
+
+- SQL Statement API requests include `parameters.query_tag = <base>:<command>`
+- The base tag comes from `.coragent.toml` / `~/.coragent/config.toml` (`query_tag.base`), defaulting to `coragent`
+- The command suffix is attached in the CLI layer via request context, so nested SQL calls inside `plan`, `apply`, `feedback`, or `run` agent selection retain the originating command name
+
+## Run Streaming Notes
+
+- `RunAgent` consumes Snowflake SSE events from the named-agent `:run` endpoint
+- `metadata.thread_id` and `response.metadata.thread_id` are accepted as either strings or integers and normalized to strings inside the client
+
 ## Related Docs
 
 - [components/auth.md](auth.md) — Config and token acquisition

--- a/reference/docs/components/config-feedbackcache-thread.md
+++ b/reference/docs/components/config-feedbackcache-thread.md
@@ -29,6 +29,11 @@ Load project and user settings from `.coragent.toml`.
 - `feedback.remote.enabled` — Enable remote feedback table mode
 - `feedback.remote.database`, `schema`, `table` — Remote feedback table location
 
+### Settings (Query Tag)
+
+- `query_tag.base` — Base query tag value for supported Snowflake requests; defaults to `coragent`
+- Effective tag format — `<base>:<command>` for command-scoped requests such as `plan`, `apply`, `run`, `eval`, and `feedback`
+
 ## FeedbackCache (`internal/feedbackcache`)
 
 ### Purpose

--- a/reference/docs/flows/plan-apply-flow.md
+++ b/reference/docs/flows/plan-apply-flow.md
@@ -39,6 +39,7 @@ flowchart LR
   - If not exists: compute grant diff vs empty; plan create
   - If exists and `deploy.grant` is specified: call `grantSvc.ShowGrants`, compute grant diff; call `diff.Diff(spec, remote)` for spec changes
   - If exists and `deploy.grant` is not specified: skip grant logic (no ShowGrants, empty grant diff)
+  - The CLI passes a command-scoped context so SQL calls are tagged as `coragent:plan` or `coragent:apply` by default
 - **Output:** `[]applyItem` (parsed, target, exists, changes, grantDiff)
 
 ### 4. Plan Output
@@ -57,6 +58,7 @@ flowchart LR
     - If not exists: `CreateAgent`, optional post-create update for `tool_resources`, `applyGrantDiff`
     - If exists and has spec changes: `UpdateAgent` with payload from `updatePayload(spec, changes)`
     - Always: `applyGrantDiff` (GRANT/REVOKE as needed; no-op when grant diff is empty, e.g. when `deploy.grant` was not specified)
+  - Any SQL executed during apply inherits the `apply` query tag context
 - **Output:** Subset of items that were created or updated
 
 ## Grant Diff

--- a/reference/docs/flows/query-feedback-threads-flow.md
+++ b/reference/docs/flows/query-feedback-threads-flow.md
@@ -18,6 +18,8 @@ These flows cover agent execution (`run`), feedback retrieval (`feedback`), and 
    - Prompt to select existing thread or create new
 4. **Run** — `client.RunAgent` with message; stream response events
 5. **State update** — On completion, update thread state (summary, last used) and save
+6. **Query tagging** — When agent-name is omitted, the pre-run agent lookup uses the `run` query tag context through the SQL API
+7. **Thread ID normalization** — SSE metadata may return `thread_id` as either a string or integer; the client normalizes it to a string before updating local thread state
 
 ### Dependencies
 
@@ -49,6 +51,7 @@ These flows cover agent execution (`run`), feedback retrieval (`feedback`), and 
 6. Display records (default negative only; `--all` for all). Response bodies are printed in full without truncation in the interactive text output
 7. Prompt to mark as checked; update remote table or local cache depending on mode
 8. In non-JSON mode, the command prints short progress lines to stdout while loading cache/remote state, refreshing, and preparing the final record list
+9. SQL-based feedback operations use the `feedback` query tag context by default (`coragent:feedback`)
 
 ### `--infer-negative` Detailed Flow
 


### PR DESCRIPTION
## Summary
- add query tag propagation for SQL-backed command flows
- tag run-time agent lookup via SHOW AGENTS when no agent name is specified
- fix run SSE parsing so numeric thread IDs are normalized to strings

## Testing
- env GOCACHE=/tmp/coragent-go-build-cache go test ./internal/config ./internal/api ./internal/cli